### PR TITLE
Potential security issue in src/zopflipng/lodepng/lodepng_util.cpp: Unchecked return from initialization function

### DIFF
--- a/src/zopflipng/lodepng/lodepng_util.cpp
+++ b/src/zopflipng/lodepng/lodepng_util.cpp
@@ -230,7 +230,7 @@ unsigned getFilterTypes(std::vector<unsigned char>& filterTypes, const std::vect
     filterTypes.swap(passes[0]);
   } else {
     lodepng::State state;
-    unsigned w, h;
+    unsigned w, h = 0;
     lodepng_inspect(&w, &h, &state, &png[0], png.size());
     /*
     Interlaced. Simplify it: put pass 6 and 7 alternating in the one vector so


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/zopflipng/lodepng/lodepng_util.cpp` 
Function: `lodepng_inspect` 
https://github.com/sagpant/zopfli/blob/7113f4e96bd26df27c46d590df95e517b966f10d/src/zopflipng/lodepng/lodepng_util.cpp#L234
Code extract:

```cpp
  } else {
    lodepng::State state;
    unsigned w, h;
    lodepng_inspect(&w, &h, &state, &png[0], png.size()); <------ HERE
    /*
    Interlaced. Simplify it: put pass 6 and 7 alternating in the one vector so
```

